### PR TITLE
Feature/add metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.5.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 
 networks:
   grafana:

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+networks:
+  grafana:
+
+volumes:
+  app_data: {}
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.21.0
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+    command:
+      - "--config.file=/etc/prometheus/dev-prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    ports:
+      - 9090:9090
+    networks:
+      - grafana
+
+  grafana:
+    image: grafana/grafana:7.3.6
+    ports:
+      - 3000:3000
+    networks:
+      - grafana
+
+  app:
+    build: .
+    ports:
+      - 8080:8080
+    networks:
+      - grafana
+

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -21,6 +21,9 @@ services:
 
   grafana:
     image: grafana/grafana:7.3.6
+    volumes:
+      - ./grafana/provisioning/:/etc/grafana/provisioning/dashboards/
+      - ./grafana/dashboards/:/etc/dashboards/
     ports:
       - 3000:3000
     networks:

--- a/grafana/dashboards/image_manager_dashboard.json
+++ b/grafana/dashboards/image_manager_dashboard.json
@@ -1,0 +1,794 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {
+        "AVG_response_time_failure": "dark-red",
+        "AVG_response_time_success": "dark-green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(http_server_requests_seconds_sum{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=~\"2..\",uri=\"/{filename}\",})/sum(http_server_requests_seconds_count{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=~\"2..\",uri=\"/{filename}\",})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "AVG_response_time_success [s]",
+          "queryType": "randomWalk",
+          "refId": "AVG_response_time_success"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(http_server_requests_seconds_sum{exception=~\".*\",method=\"GET\",outcome=~\".*\",status=~\"[45]..\",uri=\"/{filename}\",})/sum(http_server_requests_seconds_count{exception=~\".*\",method=\"GET\",outcome=~\".*\",status=~\"[45]..\",uri=\"/{filename}\",})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "AVG_response_time_failure [s]",
+          "refId": "AVG_response_time_failure"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response time (AVG) [s]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:511",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:512",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "MAX_response_time_failure": "dark-red",
+        "MAX_response_time_success": "dark-green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(http_server_requests_seconds_max{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=~\"2..\",uri=\"/{filename}\",})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "MAX_response_time_success [s]",
+          "queryType": "randomWalk",
+          "refId": "MAX_response_time_success"
+        },
+        {
+          "exemplar": true,
+          "expr": "max(http_server_requests_seconds_max{exception=~\".*\",method=\"GET\",outcome=~\".*\",status=~\"[45]..\",uri=\"/{filename}\",})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MAX_response_time_failure [s]",
+          "refId": "MAX_response_time_failure"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response time (MAX) [s]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:359",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "AVG_response_time_failure": "dark-red",
+        "AVG_response_time_success": "dark-green",
+        "AVG_response_time_success (P50) [s]": "dark-green",
+        "AVG_response_time_success (P90) [s]": "dark-blue",
+        "AVG_response_time_success (P99) [s]": "dark-purple"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "http_server_requests_seconds{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"/{filename}\",quantile=\"0.5\",}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "AVG_response_time_success (P50) [s]",
+          "queryType": "randomWalk",
+          "refId": "AVG_response_time_success (P50)"
+        },
+        {
+          "exemplar": true,
+          "expr": "http_server_requests_seconds{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"/{filename}\",quantile=\"0.9\",}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "AVG_response_time_success (P90) [s]",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "http_server_requests_seconds{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"/{filename}\",quantile=\"0.99\",}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "AVG_response_time_success (P99) [s]",
+          "refId": "AVG_response_time_success (P99) [s]"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response time (PXX) [s]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:511",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:512",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "number_of_all_requests": "blue",
+        "number_of_failed_requests": "dark-red",
+        "number_of_successful_requests": "dark-green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "number_of_failed_requests",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(http_server_requests_seconds_count{exception=~\".*\",method=\"GET\",outcome=~\".*\",status=~\"[245]..\",uri=\"/{filename}\",})",
+          "interval": "",
+          "legendFormat": "number_of_all_requests",
+          "queryType": "randomWalk",
+          "refId": "number_of_all_requests"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(http_server_requests_seconds_count{exception=\"None\",method=\"GET\",outcome=\"SUCCESS\",status=~\"[2]..\",uri=\"/{filename}\",})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "number_of_successful_requests",
+          "queryType": "randomWalk",
+          "refId": "number_of_successful_requests"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(http_server_requests_seconds_count{exception=~\".*\",method=\"GET\",outcome=~\".*\",status=~\"[45]..\",uri=\"/{filename}\",})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "number_of_failed_requests",
+          "queryType": "randomWalk",
+          "refId": "number_of_failed_requests"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Number of requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:281",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:282",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "cache_miss_count": "dark-orange"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "cache_miss_count_total",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "cache_miss_count",
+          "queryType": "randomWalk",
+          "refId": "cache_miss_count"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Number of cache misses",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:192",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:193",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(origin_traffic_size_bytes_sum[5m])",
+          "interval": "",
+          "legendFormat": "Inbound traffic [B/s]",
+          "queryType": "randomWalk",
+          "refId": "Inbound traffic"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Inbound traffic [B/s] (measured over the last 5 minutes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:682",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:683",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "default",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(outbound_traffic_size_bytes_sum[5m])",
+          "interval": "",
+          "legendFormat": "Outbound traffic [B/s]",
+          "queryType": "randomWalk",
+          "refId": "Inbound traffic"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Outbound traffic [B/s] (measured over the last 5 minutes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:682",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:683",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "image_manager_dashboard",
+  "uid": "CKEd6G_Mz",
+  "version": 8
+}

--- a/grafana/provisioning/dashboard-config.yml
+++ b/grafana/provisioning/dashboard-config.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: dashboards
+    type: file
+    updateIntervalSeconds: 15
+    options:
+      path: /etc/dashboards

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 
 networks:
   grafana:

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3"
+
+networks:
+  grafana:
+
+volumes:
+  app_data: {}
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.21.0
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+    command:
+      - "--config.file=/etc/prometheus/prod-prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    ports:
+      - 9090:9090
+    networks:
+      - grafana
+
+  app:
+    build: .
+    ports:
+      - 8080:8080
+    networks:
+      - grafana
+

--- a/prometheus/dev-prometheus.yml
+++ b/prometheus/dev-prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "IO_app"
+
+    static_configs:
+      - targets: ["app:8080"]
+

--- a/prometheus/prod-prometheus.yml
+++ b/prometheus/prod-prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 15s
+  scrape_interval: 300s
 
 scrape_configs:
   - job_name: "prometheus"

--- a/prometheus/prod-prometheus.yml
+++ b/prometheus/prod-prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "IO_app"
+
+    static_configs:
+      - targets: ["app:8080"]
+
+remote_write:
+  - url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
+    basic_auth:
+      username: GRAFANA_USERNAME
+      password: GRAFANA_PASSWORD

--- a/src/main/java/com/io/image/manager/controller/ImageController.java
+++ b/src/main/java/com/io/image/manager/controller/ImageController.java
@@ -3,6 +3,8 @@ package com.io.image.manager.controller;
 import com.io.image.manager.service.operations.ImageOperation;
 import com.io.image.manager.service.operations.ImageOperationParser;
 import com.io.image.manager.service.ImageService;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -14,21 +16,29 @@ import javax.servlet.http.HttpServletRequest;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 @RestController
 public class ImageController {
     private final ImageService imageService;
+    private final DistributionSummary outboundTrafficSummary;
 
-    public ImageController(ImageService imageService) {
+    public ImageController(ImageService imageService, PrometheusMeterRegistry mr) {
         this.imageService = imageService;
+        outboundTrafficSummary = DistributionSummary
+                .builder("response.size")
+                .baseUnit("bytes") // optional
+                .register(mr);
     }
+
 
     @ResponseBody
     @RequestMapping(value = "/{filename}", method = RequestMethod.GET, produces = MediaType.IMAGE_JPEG_VALUE)
     public ResponseEntity<Object> getImage(@PathVariable String filename, HttpServletRequest request) throws IOException {
+
+//        outboundTrafficSummary.record(request.getContentLength()); # todo: correctly record size of the request
+        outboundTrafficSummary.record(100); //dummy value
 
         List<ImageOperation> operations = ImageOperationParser.parse(request.getQueryString());
 

--- a/src/main/java/com/io/image/manager/controller/ImageController.java
+++ b/src/main/java/com/io/image/manager/controller/ImageController.java
@@ -3,7 +3,12 @@ package com.io.image.manager.controller;
 import com.io.image.manager.service.operations.ImageOperation;
 import com.io.image.manager.service.operations.ImageOperationParser;
 import com.io.image.manager.service.ImageService;
+import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,18 +32,15 @@ public class ImageController {
     public ImageController(ImageService imageService, PrometheusMeterRegistry mr) {
         this.imageService = imageService;
         outboundTrafficSummary = DistributionSummary
-                .builder("response.size")
+                .builder("outbound.traffic.size")
                 .baseUnit("bytes") // optional
                 .register(mr);
     }
 
-
+    @Timed
     @ResponseBody
     @RequestMapping(value = "/{filename}", method = RequestMethod.GET, produces = MediaType.IMAGE_JPEG_VALUE)
     public ResponseEntity<Object> getImage(@PathVariable String filename, HttpServletRequest request) throws IOException {
-
-//        outboundTrafficSummary.record(request.getContentLength()); # todo: correctly record size of the request
-        outboundTrafficSummary.record(100); //dummy value
 
         List<ImageOperation> operations = ImageOperationParser.parse(request.getQueryString());
 
@@ -50,7 +52,9 @@ public class ImageController {
         }
 
         if (image.isPresent()) {
-            return ResponseEntity.ok(dumpImage(image.get()));
+            byte[] imageArray = dumpImage(image.get());
+            outboundTrafficSummary.record(imageArray.length);
+            return ResponseEntity.ok(imageArray);
         }
 
         throw new ResponseStatusException(HttpStatus.NOT_FOUND);

--- a/src/main/java/com/io/image/manager/service/ImageServiceImpl.java
+++ b/src/main/java/com/io/image/manager/service/ImageServiceImpl.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -61,12 +63,12 @@ public class ImageServiceImpl implements ImageService {
         try {
             // FIXME: this does not look pretty
             URL url = new URL(props.getOriginServer() + filename);
-            BufferedImage image = ImageIO.read(url.openStream());
+            byte[] imgBytes = url.openStream().readAllBytes();
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(imgBytes));
             if (image == null) {
                 return Optional.empty();
             } else {
-                DataBuffer dataBuffer = image.getData().getDataBuffer();
-                originTrafficSummary.record(dataBuffer.getSize() * getDataTypeSize(dataBuffer.getDataType()));
+                originTrafficSummary.record(imgBytes.length);
                 return Optional.of(image);
             }
         } catch (Exception e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,25 @@ spring:
       on-profile: prod
 image-manager:
   origin-server: http://ORIGIN/
+---
+management:
+  metrics:
+    export.prometheus:
+        # enabling prometheus format metrics
+        enabled: true
+    distribution.percentiles.http.server.requests: 0.5, 0.95, 0.99
+    enable:
+      jvm: false
+#      tomcat: true
+  #      # expose metric for requests that meet 50ms response time SLA
+#      sla.http.server.requests: 50ms
+  endpoints:
+    web:
+      # by default Spring expose actuator endpoints on /actuator/ path but prometheus needs it be on /
+      base-path: /
+      exposure:
+        include: "*"
+      path-mapping:
+        # prometheus looks at /metrics by default when scraping for metrics
+        metrics: spring-metrics
+        prometheus: metrics

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,19 +24,14 @@ spring:
 image-manager:
   origin-server: http://ORIGIN/
   disk-cache-mount-point: cache
-
 ---
 management:
   metrics:
-    export.prometheus:
-        # enabling prometheus format metrics
-        enabled: true
+    export.prometheus.enabled: true
     distribution.percentiles.http.server.requests: 0.5, 0.95, 0.99
-    enable:
-      jvm: false
-#      tomcat: true
-  #      # expose metric for requests that meet 50ms response time SLA
-#      sla.http.server.requests: 50ms
+    web.server.request.autotime.enabled: true
+    enable.jvm: false
+    # enable.all: true # useful as a list of available metrics
   endpoints:
     web:
       # by default Spring expose actuator endpoints on /actuator/ path but prometheus needs it be on /

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,11 @@ management:
     export.prometheus.enabled: true
     distribution.percentiles.http.server.requests: 0.5, 0.95, 0.99
     web.server.request.autotime.enabled: true
-    enable.jvm: false
+    enable:
+      jvm: false
+      tomcat: false
+      system: false
+      logback: false
     # enable.all: true # useful as a list of available metrics
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,14 +28,13 @@ image-manager:
 management:
   metrics:
     export.prometheus.enabled: true
-    distribution.percentiles.http.server.requests: 0.5, 0.95, 0.99
-    web.server.request.autotime.enabled: true
+    distribution.percentiles.http.server.requests: 0.5, 0.90, 0.99
+    web.server.request.autotime.enabled: false
     enable:
       jvm: false
       tomcat: false
       system: false
       logback: false
-    # enable.all: true # useful as a list of available metrics
   endpoints:
     web:
       # by default Spring expose actuator endpoints on /actuator/ path but prometheus needs it be on /


### PR DESCRIPTION
## What?
Prometheus configuration for dev and prod Grafana.
## How?
Added:
- `./prometheus/prod-prometheus.yml` and `./prometheus/dev-prometheus.yml` - Prometheus configuration (incl. scrape interval),
- `prod-docker-compose.yml` - configuration for running the app and local Prometheus,
- `dev-docker-compose.yml` - configuration for running the app, local Prometheus and local Grafana.
---------------------------------------------------------------------------------
## What?
Local Grafana configuration.
## Why?
This configuration will make it possible to see the metrics locally during development (without the need of using Grafana Cloud, where the metrics from VM will be sent).
## How?
Added:
- `grafana/dashboards/image_manager_dashboard.json` - local Grafana dashboard configuration,
- `grafana/provisioning/dashboard-config.yml` - Grafana configuration for automatic dashboard import.